### PR TITLE
Type over newtype

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,12 @@ init-all:
 
 test-all: init-all
 	for project in ${DIR_PS_PROJECTS}/*; do \
-		make test-$$(basename $${project}); \
+		make test-$$(basename $${project}) || break; \
 	done
 
 release-all: init-all
 	for project in ${DIR_PS_PROJECTS}/*; do \
-		make release-$$(basename $${project}); \
+		make release-$$(basename $${project}) || break; \
 	done
 
 create-git-%:

--- a/resources/templates/purescript/project/bower.json
+++ b/resources/templates/purescript/project/bower.json
@@ -12,6 +12,6 @@
     "output"
   ],
   "dependencies": {
-    "purescript-aws-request": "0.0.1"
+    "purescript-aws-request": "0.0.7"
   }
 }

--- a/src/Printer/PureScript.purs
+++ b/src/Printer/PureScript.purs
@@ -14,7 +14,7 @@ import Aws (MetadataElement(MetadataElement), Service(Service))
 import FS (PartitionPaths(..), mkdirRecursive, partitionPaths, readdirRecursive)
 import Printer.PureScript.Header (header)
 import Printer.PureScript.Function (function)
-import Printer.PureScript.NewType (newType)
+import Printer.PureScript.Type (newType)
 
 projectTemplatePath = "resources/templates/purescript/project" :: FilePath
 

--- a/src/Printer/PureScript/Function.purs
+++ b/src/Printer/PureScript/Function.purs
@@ -11,16 +11,34 @@ import Printer.PureScript.Comment (comment)
 function :: String -> ServiceOperation -> String
 function name (ServiceOperation serviceOperation) = """
 {{documentation}}
-{{camelCaseName}} :: forall eff. {{inputType}} Aff (exception :: EXCEPTION | eff) {{outputType}}
-{{camelCaseName}} = Request.request serviceName "{{camelCaseName}}" {{inputFallback}}
+{{camelCaseName}} :: forall eff. {{inputEncoderType}} {{outputDecoderType}} {{inputType}} Aff (exception :: EXCEPTION | eff) {{outputType}}
+{{camelCaseName}} {{inputEncoderArg}} {{outputDecoderArg}} = Request.request {{inputEncoder}} {{outputDecoder}} serviceName "{{camelCaseName}}" {{inputFallback}}
 """ # replaceAll (Pattern "{{camelCaseName}}") (Replacement camelCaseName)
+
+    # replace (Pattern "{{inputEncoderType}}") (Replacement inputEncoderType)
+    # replace (Pattern "{{inputEncoderArg}}") (Replacement inputEncoderArg)
+    # replace (Pattern "{{inputEncoder}}") (Replacement inputEncoder)
     # replace (Pattern "{{inputType}}") (Replacement inputType)
     # replace (Pattern "{{inputFallback}}") (Replacement inputFallback)
+
+    # replace (Pattern "{{outputDecoderType}}") (Replacement outputDecoderType)
+    # replace (Pattern "{{outputDecoderArg}}") (Replacement outputDecoderArg)
+    # replace (Pattern "{{outputDecoder}}") (Replacement outputDecoder)
     # replace (Pattern "{{outputType}}") (Replacement outputType)
+
     # replace (Pattern "{{documentation}}") (Replacement documentation)
         where
             camelCaseName = (take 1 name # toLower) <> (drop 1 name)
+
+            inputEncoderType = unNullOrUndefined serviceOperation.input # maybe "" (\(ServiceShapeName { shape }) -> "Request.Encode " <> shape <> " ->")
+            inputEncoderArg = unNullOrUndefined serviceOperation.input # maybe "" (\_ -> "encode")
+            inputEncoder = unNullOrUndefined serviceOperation.input # maybe "Types.encodeNoInput" (\_ -> inputEncoderArg)
             inputType = unNullOrUndefined serviceOperation.input # maybe "" (\(ServiceShapeName { shape }) -> shape <> " ->")
-            inputFallback = unNullOrUndefined serviceOperation.input # maybe "(Types.NoInput unit)" (\_ -> "")
-            outputType =  unNullOrUndefined serviceOperation.output # maybe "Types.NoOutput" (\(ServiceShapeName { shape }) -> shape)
+            inputFallback = unNullOrUndefined serviceOperation.input # maybe "Types.noInput" (\_ -> "")
+
+            outputDecoderType = unNullOrUndefined serviceOperation.output # maybe "" (\(ServiceShapeName { shape }) -> "Request.Decode " <> shape <> " ->")
+            outputDecoderArg = unNullOrUndefined serviceOperation.output # maybe "" (\_ -> "decode")
+            outputDecoder = unNullOrUndefined serviceOperation.output # maybe "Types.decodeNoOutput" (\_ -> outputDecoderArg)
+            outputType =  unNullOrUndefined serviceOperation.output # maybe "Unit" (\(ServiceShapeName { shape }) -> shape)
+
             documentation = unNullOrUndefined serviceOperation.documentation # maybe "" comment

--- a/src/Printer/PureScript/Header.purs
+++ b/src/Printer/PureScript/Header.purs
@@ -16,13 +16,6 @@ module AWS.{{serviceName}} where
 import Prelude
 import Control.Monad.Aff (Aff)
 import Control.Monad.Eff.Exception (EXCEPTION)
-import Data.Foreign as Foreign
-import Data.Foreign.Class (class Decode, class Encode)
-import Data.Foreign.Generic (defaultOptions, genericDecode, genericEncode)
-import Data.Foreign.NullOrUndefined as NullOrUndefined
-import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Show (genericShow)
-import Data.Newtype (class Newtype)
 import Data.StrMap as StrMap
 
 import AWS.Request as Request

--- a/src/Printer/PureScript/Header.purs
+++ b/src/Printer/PureScript/Header.purs
@@ -17,6 +17,7 @@ import Prelude
 import Control.Monad.Aff (Aff)
 import Control.Monad.Eff.Exception (EXCEPTION)
 import Data.StrMap as StrMap
+import Data.Maybe as Maybe
 
 import AWS.Request as Request
 import AWS.Request.Types as Types

--- a/src/Printer/PureScript/Type.purs
+++ b/src/Printer/PureScript/Type.purs
@@ -4,7 +4,7 @@ import Prelude
 import Data.Array (elem)
 import Data.Foreign.NullOrUndefined (NullOrUndefined(..), unNullOrUndefined)
 import Data.Maybe (Maybe(..), fromMaybe, maybe)
-import Data.String (Pattern(Pattern), Replacement(Replacement), drop, dropWhile, joinWith, replace, replaceAll, take, toUpper)
+import Data.String (Pattern(Pattern), Replacement(Replacement), drop, dropWhile, joinWith, replace, take, toUpper)
 import Data.StrMap (StrMap, isEmpty, filterKeys, toArrayWithKey)
 
 import Aws (MetadataElement(MetadataElement), ServiceShape(ServiceShape), ServiceShapeName(ServiceShapeName))
@@ -49,16 +49,8 @@ newType metadata name serviceShape = output
 newType' :: MetadataElement -> String -> ServiceShape -> String
 newType' metadata name serviceShape@(ServiceShape { documentation }) = """
 {{documentation}}
-newtype {{name}} = {{name}} {{type}}
-derive instance newtype{{name}} :: Newtype {{name}} _
-derive instance repGeneric{{name}} :: Generic {{name}} _
-instance show{{name}} :: Show {{name}} where
-  show = genericShow
-instance decode{{name}} :: Decode {{name}} where
-  decode = genericDecode $ defaultOptions { unwrapSingleConstructors = true }
-instance encode{{name}} :: Encode {{name}} where
-  encode = genericEncode $ defaultOptions { unwrapSingleConstructors = true }
-""" # replaceAll (Pattern "{{name}}") (Replacement $ name)
+type {{name}} = {{type}}
+""" # replace (Pattern "{{name}}") (Replacement $ name)
     # replace (Pattern "{{type}}") (Replacement $ recordType metadata name serviceShape)
     # replace (Pattern "{{documentation}}") (Replacement $ maybe "" comment $ unNullOrUndefined documentation)
 

--- a/src/Printer/PureScript/Type.purs
+++ b/src/Printer/PureScript/Type.purs
@@ -1,4 +1,4 @@
-module Printer.PureScript.NewType where
+module Printer.PureScript.Type where
 
 import Prelude
 import Data.Array (elem)


### PR DESCRIPTION
Few changes related the use of `type` instead of `newtype`, and requests requiring encoder / decoder.

https://github.com/purescript-aws-sdk/gen/issues/10